### PR TITLE
Fix yarn test-contracts command

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "compile-contracts": "truffle compile",
     "migrate-contracts": "truffle migrate",
-    "test-contracts": "truffle test",
+    "test-contracts": "truffle test --network develop",
     "run-server": "node ./household-server/index.js",
     "run-ui": "node ./household-ui/index.js",
     "run-sensor": "node ./mock-sensor/index.js",

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -1,16 +1,6 @@
 module.exports = {
-  // Uncommenting the defaults below 
-  // provides for an easier quick-start with Ganache.
-  // You can also follow this format for other networks;
-  // see <http://truffleframework.com/docs/advanced/configuration>
-  // for more details on how to specify configuration options!
   networks: {
     development: {
-      host: "127.0.0.1",
-      port: 7545,
-      network_id: "*"
-    },
-    test: {
       host: "127.0.0.1",
       port: 7545,
       network_id: "*"


### PR DESCRIPTION
Due to the fact that we set some configuration in `truffle-config`
truffle is looking for a running ethereum client to run the tests
against. I changed the `yarn test-contracts` in a way that it uses its
internal `truffle develop` to run the tests. So I would suggest when
running tests locally with a running ethereum client run
`truffle test`, which uses the specified config in truffle-config.
When running tests via `yarn test-contracts` it will run the tests in
clean room environment.

Fixes https://github.com/cp-ss2019/decentralized-energy-trading/issues/16.