### PR TITLE
Partly FIFS settlement (netting) and tests (still unstable)

### DIFF
--- a/contracts/FifsUtility.sol
+++ b/contracts/FifsUtility.sol
@@ -70,7 +70,7 @@ contract FifsUtility is Utility {
       for (uint256 i = 0; i < householdListNoEnergy.length; i++) {
         Household storage hhNeeded = households[householdListNoEnergy[i]];
         // calculate % of energy on neededRenewableEnergy by household i
-        int256 proportionNeedRenewableEnergy = 100 * (-1) * hhNeeded.renewableEnergy / (-1) * neededRenewableEnergy;
+        int256 proportionNeedRenewableEnergy = 100 * (-1) * hhNeeded.renewableEnergy / ((-1) * neededRenewableEnergy);
         // calculate amount of energy on availableRenewableEnergy by household i
         int256 amountAvailableRenewableEnergy = availableRenewableEnergy * proportionNeedRenewableEnergy / 100;
         for (uint256 j = 0; j < householdListWithEnergy.length; j++) {
@@ -110,19 +110,19 @@ contract FifsUtility is Utility {
         }
       }
     } else {
-      // totalRenewableEnergy > 0
+      // totalRenewableEnergy >= 0
       // enough renewable energy for settlement; availableRenewableEnergy >= neededRenewableEnergy
       for (uint256 i = 0; i < householdListWithEnergy.length; i++) {
         Household storage hhAvailable = households[householdListWithEnergy[i]];
         // calculate % of energy on availableRenewableEnergy by household i
         int256 proportionAvailableRenewableEnergy = 100 * hhAvailable.renewableEnergy / availableRenewableEnergy;
         // calculate amount of energy on neededRenewableEnergy by household i
-        int256 amountNeededRenewableEnergy = neededRenewableEnergy * proportionAvailableRenewableEnergy / 100;
+        int256 amountNeededRenewableEnergy = (-1) * neededRenewableEnergy * proportionAvailableRenewableEnergy / 100;
         for (uint256 j = 0; j < householdListNoEnergy.length; j++) {
           // settle energy
           if (amountNeededRenewableEnergy > (-1) * households[householdListNoEnergy[j]].renewableEnergy) {
             // energy for settlement by household i is > needed by household j; household i can serve more households
-            int256 energyTransferred = households[householdListNoEnergy[j]].renewableEnergy;
+            int256 energyTransferred = (-1) * households[householdListNoEnergy[j]].renewableEnergy;
 
             households[householdListWithEnergy[i]].renewableEnergy -= energyTransferred;
             amountNeededRenewableEnergy -= energyTransferred;

--- a/contracts/FifsUtility.sol
+++ b/contracts/FifsUtility.sol
@@ -48,24 +48,16 @@ contract FifsUtility is Utility {
     // amount of needed renewable energy
     int256 neededRenewableEnergy;
 
-    // group households into households sending renewable energy and households recievin renewable energy
+    // group households into households with positive amount of renewable energy
+    // and negative amount of renewable energy
     for (uint256 i = 0; i < householdList.length; i++) {
-      if (households[householdList[i]].renewableEnergy + households[householdList[i]].nonRenewableEnergy <= 0) {
-        // sum of renewable and non-renewable energy is negative or zero; no energy for settlement
+      if (households[householdList[i]].renewableEnergy < 0) {
+        // households with negative amount of renewable energy
         householdListNoEnergy.push(householdList[i]);
-      } else {
-        // sum of renewable and non-renewable energy is positive
-        if (households[householdList[i]].renewableEnergy > 0 && households[householdList[i]].nonRenewableEnergy > 0) {
-          // both amounts of renewable and non-renewable energy are positive
-          householdListWithEnergy.push(householdList[i]);
-          // add amount of renewable energy to available energy for settlement
-          availableRenewableEnergy = (households[householdList[i]].renewableEnergy);
-        } else if (households[householdList[i]].renewableEnergy > 0 && households[householdList[i]].nonRenewableEnergy < 0) {
-          // amount of renewable energy is positive
-          householdListWithEnergy.push(householdList[i]);
-          // add gap between renewable and non-renewable energy to available energy for settlement
-          availableRenewableEnergy = (households[householdList[i]].renewableEnergy - households[householdList[i]].nonRenewableEnergy);
-        }
+      } else if (households[householdList[i]].renewableEnergy > 0) {
+        // households with positive amount of renewable energy
+        householdListWithEnergy.push(householdList[i]);
+        availableRenewableEnergy += households[householdList[i]].renewableEnergy;
       }
     }
 

--- a/contracts/FifsUtility.sol
+++ b/contracts/FifsUtility.sol
@@ -1,0 +1,59 @@
+pragma solidity >=0.5.0 <0.6.0;
+
+import "./Utility.sol";
+
+
+contract FifsUtility is Utility {
+
+  // Number of successful settlements done
+  // Used for backtracking
+  uint256 public checkpoint;
+
+  // Iterable list of all current households
+  address[] householdList;
+
+  struct Deed {
+    bool active;
+    address to;
+    uint256 energyTransferred;
+    bool isRenewable;
+  }
+
+  // (household, checkpoint) -> Deed
+  mapping(address => mapping(uint256 => Deed)) deeds;
+
+  constructor() public Utility() {
+    checkpoint = 0;
+  }
+
+  function addHousehold(address _household) external onlyOwner returns (bool) {
+    if (super._addHousehold(_household)) {
+      householdList.push(_household);
+    }
+  }
+
+  function settle() external returns (bool) {
+    checkpoint += 1;
+    return true;
+  }
+
+  /**
+   * @dev 'Finalizes' an energy transfer by emitting event EnergyTransfer
+   * @param _household address of the household owner
+   * @param _checkpoint uint256 the settlement number the sender wants to retrieve the reward
+   * @return uint256 the amount of energy transferred
+   */
+  function retrieveReward(address _household, uint256 _checkpoint) external onlyHousehold(_household) returns (uint256 energyTransferred) {
+    Deed storage deed = deeds[_household][_checkpoint];
+    require(deed.active, "Deed does not exist");
+
+    emit EnergyTransfer(
+      _household,
+      deed.to,
+      deed.energyTransferred,
+      deed.isRenewable);
+
+    energyTransferred = deed.energyTransferred;
+    delete deeds[_household][_checkpoint];
+  }
+}

--- a/contracts/FifsUtility.sol
+++ b/contracts/FifsUtility.sol
@@ -5,12 +5,16 @@ import "./Utility.sol";
 
 contract FifsUtility is Utility {
 
-  // Number of successful settlements done
-  // Used for backtracking
+  // number of successful settlements done
+  // used for backtracking
   uint256 public checkpoint;
 
-  // Iterable list of all current households
+  // iterable list of all households
   address[] householdList;
+  // iterable list of all current households with positive amount of energy
+  address[] householdListWithEnergy;
+  // iterable list of all current households with negative amount of energy
+  address[] householdListNoEnergy;
 
   struct Deed {
     bool active;
@@ -33,6 +37,38 @@ contract FifsUtility is Utility {
   }
 
   function settle() external returns (bool) {
+    require(totalRenewableEnergy > 0, "No renewable energy available for settlement.");
+
+    // restructure this in seperate function ?
+    // total amount of renewable energy for settlement
+    uint256 availableRenewableEnergy;
+
+    // group households into households sending renewable energy and households recievin renewable energy
+    for (uint256 i = 0; i < householdList.length; i++) {
+      if (households[householdList[i]].renewableEnergy + households[householdList[i]].nonRenewableEnergy <= 0) {
+        // sum of renewable and non-renewable energy is negative or zero; no energy for settlement
+        householdListNoEnergy.push(householdList[i]);
+      } else {
+        // sum of renewable and non-renewable energy is positive
+        if (households[householdList[i]].renewableEnergy > 0 && households[householdList[i]].nonRenewableEnergy > 0) {
+          // both amounts of renewable and non-renewable energy are positive
+          householdListWithEnergy.push(householdList[i]);
+          // add amount of renewable energy to available energy for settlement
+          availableRenewableEnergy = uint256(households[householdList[i]].renewableEnergy);
+        } else if (households[householdList[i]].renewableEnergy > 0 && households[householdList[i]].nonRenewableEnergy < 0) {
+          // amount of renewable energy is positive
+          householdListWithEnergy.push(householdList[i]);
+          // add gap between renewable and non-renewable energy to available energy for settlement
+          availableRenewableEnergy = uint256(households[householdList[i]].renewableEnergy - households[householdList[i]].nonRenewableEnergy);
+        }
+      }
+    }
+
+    // clean setup for next settlement
+    delete availableRenewableEnergy;
+    delete householdListNoEnergy;
+    delete householdListWithEnergy;
+
     checkpoint += 1;
     return true;
   }

--- a/contracts/FifsUtility.sol
+++ b/contracts/FifsUtility.sol
@@ -9,11 +9,11 @@ contract FifsUtility is Utility {
   uint256 public checkpoint;
 
   // iterable list of all households
-  address[] householdList;
+  address[] public householdList;
   // iterable list of all current households with positive amount of renewable energy
-  address[] householdListWithEnergy;
+  address[] public householdListWithEnergy;
   // iterable list of all current households with negative amount of renewable energy
-  address[] householdListNoEnergy;
+  address[] public householdListNoEnergy;
 
   struct Deed {
     bool active;

--- a/contracts/IUtility.sol
+++ b/contracts/IUtility.sol
@@ -7,7 +7,7 @@ pragma solidity >=0.5.0 <0.6.0;
 interface IUtility {
 
   // event for energy transfer triggered by settlement (netting)
-  event EnergyTransfer(address indexed household, int256 energy);
+  event EnergyTransfer(address indexed from, address indexed to, uint256 energy, bool isRenewable);
 
   event NewHousehold(address indexed household);
 

--- a/contracts/IUtility.sol
+++ b/contracts/IUtility.sol
@@ -7,7 +7,7 @@ pragma solidity >=0.5.0 <0.6.0;
 interface IUtility {
 
   // event for energy transfer triggered by settlement (netting)
-  event EnergyTransfer(address indexed from, address indexed to, uint256 energy, bool isRenewable);
+  event EnergyTransfer(address indexed from, address indexed to, int256 energy, bool isRenewable);
 
   event NewHousehold(address indexed household);
 

--- a/contracts/Utility.sol
+++ b/contracts/Utility.sol
@@ -52,16 +52,7 @@ contract Utility is IUtility, Mortal {
    * @return success bool if household does not already exists, should only be called by some authority
    */
   function addHousehold(address _household) external onlyOwner returns (bool) {
-    require(!households[_household].initialized, "Household already exists.");
-
-    // add new household to mapping
-    Household storage hh = households[_household];
-    hh.initialized = true;
-    hh.renewableEnergy = 0;
-    hh.nonRenewableEnergy = 0;
-
-    emit NewHousehold(_household);
-    return true;
+    return _addHousehold(_household);
   }
 
   /**
@@ -154,6 +145,24 @@ contract Utility is IUtility, Mortal {
   function settle() external returns (bool) {
     // ToDo
     return false;
+  }
+
+  /**
+   * @dev see Utility.addHousehold
+   * @param _household address of household
+   * @return bool success
+   */
+  function _addHousehold(address _household) internal returns (bool) {
+    require(!households[_household].initialized, "Household already exists.");
+
+    // add new household to mapping
+    Household storage hh = households[_household];
+    hh.initialized = true;
+    hh.renewableEnergy = 0;
+    hh.nonRenewableEnergy = 0;
+
+    emit NewHousehold(_household);
+    return true;
   }
 
   /**

--- a/migrations/.eslintrc
+++ b/migrations/.eslintrc
@@ -1,0 +1,9 @@
+{
+  "env": {
+    "node": true
+  },
+  "globals": {
+    "artifacts": "readonly",
+    "contract": "readonly"
+  }
+}

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -1,5 +1,7 @@
 const FifsUtility = artifacts.require("FifsUtility");
+const Utility = artifacts.require("Utility");
 
 module.exports = function(deployer) {
   deployer.deploy(FifsUtility);
+  deployer.deploy(Utility);
 };

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -1,5 +1,5 @@
-const Utility = artifacts.require("Utility");
+const FifsUtility = artifacts.require("FifsUtility");
 
 module.exports = function(deployer) {
-  deployer.deploy(Utility);
+  deployer.deploy(FifsUtility);
 };

--- a/test/fifsUtility.test.js
+++ b/test/fifsUtility.test.js
@@ -16,9 +16,31 @@ contract("FifsUtility", ([owner, hh1, hh2, hh3, hh4]) => {
     });
   });
 
-  describe("Checkpoint", () => {
+  describe.only("Checkpoint", () => {
+    beforeEach(async () => {
+      await this.instance.addHousehold(hh1);
+      await this.instance.addHousehold(hh2);
+      await this.instance.addHousehold(hh3);
+      await this.instance.addHousehold(hh4);
+    });
+
     it("should be initialized with 0", async () => {
       expect(await this.instance.checkpoint()).to.be.bignumber.that.is.zero;
+    });
+
+    context("After settlement", async () => {
+      beforeEach(async () => {
+        await this.instance.settle();
+      });
+
+      it("first settlement; should be 1", async () => {
+        expect(await this.instance.checkpoint()).to.be.bignumber.equal("1");
+      });
+
+      it("second settlement; should be 2", async () => {
+        await this.instance.settle();
+        expect(await this.instance.checkpoint()).to.be.bignumber.equal("2");
+      });
     });
   });
 

--- a/test/fifsUtility.test.js
+++ b/test/fifsUtility.test.js
@@ -1,0 +1,57 @@
+/* eslint-disable no-unused-vars */
+/* eslint-disable no-unused-expressions */
+const FifsUtility = artifacts.require("FifsUtility");
+const {
+  BN,
+  constants,
+  expectEvent,
+  shouldFail
+} = require("openzeppelin-test-helpers");
+const expect = require("chai").use(require("chai-bn")(BN)).expect;
+
+contract("FifsUtility", ([owner, household, other]) => {
+  beforeEach(async () => {
+    this.instance = await FifsUtility.new({
+      from: owner
+    });
+  });
+
+  describe("Checkpoint", () => {
+    it("should be initialized with 0", async () => {
+      expect(await this.instance.checkpoint()).to.be.bignumber.that.is.zero;
+    });
+  });
+
+  describe("Households", () => {
+    context("with a new household", async () => {
+      beforeEach(async () => {
+        ({ logs: this.logs } = await this.instance.addHousehold(household));
+      });
+
+      it("should create a new household", async () => {
+        const hh = await this.instance.getHousehold(household);
+
+        expect(hh[0]).to.be.true; // initialized
+        expect(hh[1]).to.be.bignumber.that.is.zero; // renewableEnergy
+        expect(hh[2]).to.be.bignumber.that.is.zero; // nonRenewableEnergy
+      });
+
+      it("should store addresses in householdList", async () => {
+        expect((await this.instance.householdList(0)) == household);
+
+        await this.instance.addHousehold(other);
+        expect((await this.instance.householdList(1)) == other);
+      });
+
+      it("emits event NewHousehold", async () => {
+        expectEvent.inLogs(this.logs, "NewHousehold", {
+          household: household
+        });
+      });
+
+      it("reverts when attempting to add an existing household", async () => {
+        await shouldFail.reverting(this.instance.addHousehold(household));
+      });
+    });
+  });
+});


### PR DESCRIPTION
Devides contracts in `Utility.sol` for basic utility functions and `FifsUtility.sol` for partly FIFS settlement. Refer issue #19.
`FifsUtility.sol` inherrites from `Utility.sol` and overrides functions `addHousehold` and `settle`. 
Further, `FifsUtility.sol` implements first *fair* FIFS netting algorithm in `settle`. 
`fifsUtility.test.js` tests `FifsUtility.sol` for `addHousehold`, `retrieveReward` and for the different cases of `settle`. This PR mainly refers to the second part of issue #11.

Test the contracts: `yarn test-contracts` or `truffle test`.