### PR TITLE
Add `test-contracts` script for win32 and win64

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,9 @@
   "scripts": {
     "compile-contracts": "truffle compile",
     "migrate-contracts": "truffle migrate",
-    "test-contracts": "truffle test ./test/contracts/* --network develop",
-    "test-contracts:win32:win64": "truffle test ./test/contracts/utility.test.js --network develop && truffle test ./test/contracts/fifsUtility.test.js --network develop",
+    "test-contracts": "run-script-os",
+    "test-contracts:linux:darwin": "truffle test './test/contracts/*' --network develop",
+    "test-contracts:win32": "truffle test ./test/contracts/utility.test.js --network develop && truffle test ./test/contracts/fifsUtility.test.js --network develop",
     "run-server": "node ./household-server/index.js",
     "run-ui": "node ./household-ui/index.js",
     "run-sensor": "node ./mock-sensor/index.js",
@@ -34,6 +35,7 @@
     "openzeppelin-solidity": "^2.2.0",
     "openzeppelin-test-helpers": "^0.3.2",
     "prettier": "^1.17.0",
+    "run-script-os": "^1.0.5",
     "solium": "^1.2.4",
     "truffle": "^5.0.13"
   },

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "compile-contracts": "truffle compile",
     "migrate-contracts": "truffle migrate",
-    "test-contracts": "truffle test ./test/contracts/* --network develop",
+    "test-contracts:darwin:linux": "truffle test ./test/contracts/* --network develop",
+    "test-contracts:win32:win64": "truffle test ./test/contracts/utility.test.js --network develop && truffle test ./test/contracts/fifsUtility.test.js --network develop",
     "run-server": "node ./household-server/index.js",
     "run-ui": "node ./household-ui/index.js",
     "run-sensor": "node ./mock-sensor/index.js",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "migrate-contracts": "truffle migrate",
     "test-contracts": "run-script-os",
     "test-contracts:linux:darwin": "truffle test './test/contracts/*' --network develop",
-    "test-contracts:win32": "truffle test ./test/contracts/utility.test.js --network develop && truffle test ./test/contracts/fifsUtility.test.js --network develop",
+    "test-contracts:win32": ".\\test-contracts.bat",
     "run-server": "node ./household-server/index.js",
     "run-ui": "node ./household-ui/index.js",
     "run-sensor": "node ./mock-sensor/index.js",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "migrate-contracts": "truffle migrate",
     "test-contracts": "run-script-os",
     "test-contracts:linux:darwin": "truffle test './test/contracts/*' --network develop",
-    "test-contracts:win32": ".\\test-contracts.bat",
+    "test-contracts:win32": ".\\test-contracts.bat --network develop",
     "run-server": "node ./household-server/index.js",
     "run-ui": "node ./household-ui/index.js",
     "run-sensor": "node ./mock-sensor/index.js",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "compile-contracts": "truffle compile",
     "migrate-contracts": "truffle migrate",
-    "test-contracts:darwin:linux": "truffle test ./test/contracts/* --network develop",
+    "test-contracts": "truffle test ./test/contracts/* --network develop",
     "test-contracts:win32:win64": "truffle test ./test/contracts/utility.test.js --network develop && truffle test ./test/contracts/fifsUtility.test.js --network develop",
     "run-server": "node ./household-server/index.js",
     "run-ui": "node ./household-ui/index.js",

--- a/test-contracts.bat
+++ b/test-contracts.bat
@@ -1,0 +1,2 @@
+for %%i in (.\\test\\contracts\\*.test.js) do call set "filelist=%%filelist%% %%i"
+yarn truffle test %filelist%

--- a/test-contracts.bat
+++ b/test-contracts.bat
@@ -1,2 +1,3 @@
+@echo off
 for %%i in (.\\test\\contracts\\*.test.js) do call set "filelist=%%filelist%% %%i"
-yarn truffle test %filelist%
+yarn truffle test %filelist% %*

--- a/yarn.lock
+++ b/yarn.lock
@@ -3411,6 +3411,11 @@ run-async@^2.2.0:
   dependencies:
     is-promise "^2.1.0"
 
+run-script-os@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/run-script-os/-/run-script-os-1.0.5.tgz#2cf188122bc6ee2ad8faa4f2e53d0aa8be08116f"
+  integrity sha512-uDMVaOAB9M4Q8KcQRVgt7jTZlGNIrlTPbEO+wEA+7kTTMsrL6/JYTkrRWuGF7VpZHHKLreTd/FN7J+EYEaUvhQ==
+
 rxjs@^6.4.0:
   version "6.5.1"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.5.1.tgz#f7a005a9386361921b8524f38f54cbf80e5d08f4"


### PR DESCRIPTION
`yarn test-contracts` does not execute on win32 and win64 because of path specification `*`.
Add script for win32 and win64, called `test-contracts:win32:win64`.

PR #47 solved the issue #45 for darwin:linux.
This PR should solve the issue #45 for win32:win64.

Can someone test this on win32 or win64?
Further, if someone knows how to simplify the script `test-contracts:win32:win64` feel free to push.