### PR TITLE
[HHS] Include address in getHousehold

### DIFF
--- a/contracts/UtilityBase.sol
+++ b/contracts/UtilityBase.sol
@@ -122,6 +122,7 @@ contract UtilityBase is Mortal, IUtilityBase {
   function getHousehold(address _household)
     external
     view
+    onlyHousehold(_household)
     householdExists(_household)
     returns (bool initialized,
              int256 renewableEnergy,

--- a/household-server/transaction-handler.js
+++ b/household-server/transaction-handler.js
@@ -110,6 +110,7 @@ module.exports = {
    *  '4': number,
    *  '5': number,
    *  '6': number,
+   *  address: address,
    *  initialized: boolean,
    *  renewableEnergy: number,
    *  nonRenewableEnergy: number,
@@ -128,7 +129,9 @@ module.exports = {
     );
 
     const householdData = await contract.methods.getHousehold(address).call();
-    let hhStats = {};
+    let hhStats = {
+      address
+    };
     for (const key in householdData) {
       if (typeof householdData[key] === "boolean") {
         hhStats[key] = householdData[key];


### PR DESCRIPTION
Add modifer `onlyHousehold` to `getHousehold` in `UtilityBase.sol`.
Include `address` of household in `getHousehold` return object in `transaction-handler.js`.